### PR TITLE
rename app

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>FreeM</title>
+    <title>fleamarket_sample_74d</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
# WHAT
アクセス時に名前が以前のままだったため、アプリ名を修正。
# WHY
アプリ名とタイトルが異なってると違和感が残るため。